### PR TITLE
GITHUB-16: fix GCP build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Note that you'll be prompted to type your GCP project name. When a new instance 
 gcloud compute ssh --project $PROJECT_NAME --zone us-central1-a gpu
 ```
 
-Deployment script automatically clones this repository to `/tmp` folder. Now you can build Vosk images on a relatively powerful machine:
+Clone this repo and build Vosk images on a relatively powerful machine:
 
 ```shell
-cd /tmp/vosk-api-gpu/gcp && ./build.sh
+git clone https://github.com/sskorol/vosk-api-gpu && cd vosk-api-gpu/gcp && ./build.sh
 ```
 
 Note that some variables are hardcoded at the moment. Feel free to change them if you want.

--- a/gcp/build.sh
+++ b/gcp/build.sh
@@ -3,7 +3,7 @@
 TAG=0.3.37
 CUDA_IMAGE=11.3.1-devel-ubuntu20.04
 MODEL_NAME=vosk-model-ru-0.22
-MODEL_ARCHIVE="$MODEL.zip"
+MODEL_ARCHIVE="$MODEL_NAME.zip"
 
 # Install docker-compose
 sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -27,8 +27,8 @@ sudo systemctl restart docker
 
 # Patch model
 cd ../ && wget "https://alphacephei.com/vosk/models/$MODEL_ARCHIVE" \
-  && unzip MODEL_ARCHIVE \
-  && rm -f MODEL_ARCHIVE \
+  && unzip $MODEL_ARCHIVE \
+  && rm -f $MODEL_ARCHIVE \
   && mv $MODEL_NAME model \
   && sed -i '1d' ./model/conf/model.conf \
   && cat <<EOT >> ./model/conf/ivector.conf

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -30,6 +30,4 @@ resource "google_compute_instance" "default" {
   metadata = {
     install-nvidia-driver = "True"
   }
-
-  metadata_startup_script = "git clone https://github.com/sskorol/vosk-api-gpu.git /tmp/vosk"
 }


### PR DESCRIPTION
There was an invalid model variable left in a build script that caused failures.
Apart from that, there was removed a startup script which clones the repo to /tmp folder, as there are lots of permission issues occur after ssh'ing with a specific user. It'd make more sense to let a user clone the repo into their home folder after deployment.