### PR TITLE
GITHUB-20: hotfix for broken Dockerfile keys

### DIFF
--- a/gcp/build.sh
+++ b/gcp/build.sh
@@ -5,7 +5,7 @@ help()
     echo ""
     nvcc -V
     echo ""
-    echo "Usage: $0 -c 11.3.1-devel-ubuntu20.04 -t 0.3.37"
+    echo "Usage: $0 -c 11.3.1-devel-ubuntu20.04 -t 0.3.37 -m vosk-model-en-us-0.22"
     echo -e "\t-c CUDA image version, e.g. 11.3.1-devel-ubuntu20.04"
     echo -e "\t-t Image tag, based on Vosk version, e.g. 0.3.37"
     echo -e "\t-m Model name, based on https://alphacephei.com/vosk/models, e.g. vosk-model-en-us-0.22"

--- a/pc/Dockerfile
+++ b/pc/Dockerfile
@@ -5,6 +5,9 @@ FROM nvidia/cuda:$CUDA_TAG
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Patch for broken keys
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
 	autoconf \


### PR DESCRIPTION
Seems like latest NVIDIA images have issues with GPG keys. So users can't do `apt update`. This update adds a missing key as a tmp solution, until base images are not officially rebuilt.